### PR TITLE
EF Core 5 views support

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -54,7 +54,8 @@ namespace LinqToDB.EntityFrameworkCore
 			{
 				if (typeof(T) == typeof(TableAttribute))
 				{
-					return new[] { (T)(Attribute)new TableAttribute(et.GetTableName()) { Schema = et.GetSchema() } };
+					var storeObjectId = GetStoreObjectIdentifier(et);
+					return new[] { (T)(Attribute)new TableAttribute(storeObjectId!.Value.Name) { Schema = storeObjectId!.Value.Schema } };
 				}
 				if (typeof(T) == typeof(QueryFilterAttribute))
 				{
@@ -162,7 +163,7 @@ namespace LinqToDB.EntityFrameworkCore
 								                  .FirstOrDefault(v => CompareProperty(v.p, memberInfo))?.index ?? 0;
 						}
 
-						var storeObjectId = StoreObjectIdentifier.Create(et, StoreObjectType.Table);
+						var storeObjectId = GetStoreObjectIdentifier(et);
 
 						return new T[]{(T)(Attribute) new ColumnAttribute
 						{
@@ -323,6 +324,15 @@ namespace LinqToDB.EntityFrameworkCore
 			{
 				expressionPrinter.Print(Expression);
 			}
+		}
+
+		private StoreObjectIdentifier? GetStoreObjectIdentifier(IEntityType entityType)
+		{
+			return entityType.GetTableName() switch
+			{
+				not null => StoreObjectIdentifier.Create(entityType, StoreObjectType.Table),
+				null     => StoreObjectIdentifier.Create(entityType, StoreObjectType.View),
+			};
 		}
 
 		private Sql.ExpressionAttribute? GetDbFunctionFromMethodCall(Type type, MethodInfo methodInfo)

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/EventView.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/EventView.cs
@@ -1,0 +1,7 @@
+﻿namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.Models.NpgSqlEntities
+{
+	public class EventView
+	{
+		public string Name { get; set; } = null!;
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/NpgSqlEnititesContext.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/NpgSqlEnititesContext.cs
@@ -14,6 +14,12 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.Models.NpgSqlEntities
 			modelBuilder.Entity<Event>(entity =>
 				entity.Property(e => e.Duration).HasColumnType("tsrange")
 			);
+
+			modelBuilder.Entity<EventView>(entity =>
+				{
+					entity.HasNoKey();
+					entity.ToView("EventsView", "views");
+				});
 		}
 
 		public virtual DbSet<Event> Events { get; set; } = null!;

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/NpgSqlTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/NpgSqlTests.cs
@@ -34,9 +34,10 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests
 			var ctx = new NpgSqlEnititesContext(_options);
 			ctx.Database.EnsureDeleted();
 			ctx.Database.EnsureCreated();
+			ctx.Database.ExecuteSqlRaw("create schema \"views\"");
+			ctx.Database.ExecuteSqlRaw("create view \"views\".\"EventsView\" as select \"Name\" from \"Events\"");
 			return ctx;
 		}
-
 
 		[Test]
 		public void TestFunctionsMapping()
@@ -54,6 +55,17 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests
 			}
 		}
 
-	
+		[Test]
+		public void TestViewMapping()
+		{
+			using (var db = CreateNpgSqlExntitiesContext())
+			{
+				var query = db.Set<EventView>().Where(e =>
+					e.Name.StartsWith("any"));
+
+				var efResult = query.ToArray();
+				var l2dbResult = query.ToLinqToDB().ToArray();
+			}
+		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/NpgSqlTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/NpgSqlTests.cs
@@ -29,7 +29,7 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests
 			_options = optionsBuilder.Options;
 		}
 
-		private NpgSqlEnititesContext CreateNpgSqlExntitiesContext()
+		private NpgSqlEnititesContext CreateNpgSqlEntitiesContext()
 		{
 			var ctx = new NpgSqlEnititesContext(_options);
 			ctx.Database.EnsureDeleted();
@@ -42,7 +42,7 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests
 		[Test]
 		public void TestFunctionsMapping()
 		{
-			using (var db = CreateNpgSqlExntitiesContext())
+			using (var db = CreateNpgSqlEntitiesContext())
 			{
 				var date = DateTime.UtcNow;
 
@@ -58,7 +58,7 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests
 		[Test]
 		public void TestViewMapping()
 		{
-			using (var db = CreateNpgSqlExntitiesContext())
+			using (var db = CreateNpgSqlEntitiesContext())
 			{
 				var query = db.Set<EventView>().Where(e =>
 					e.Name.StartsWith("any"));


### PR DESCRIPTION
Added views support for EF Core 5.

In earlier versions of EF Core `IEntityType.GetTableName()` returned either table name or view name. 
But since `5.0` it returns `null` on `GetTableName()` in favor of using separate extension methods for different type of objects.