### PR TITLE
Avoid dealock in low thread condition

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
@@ -158,8 +158,8 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 		/// <returns>Query result as <see cref="IAsyncEnumerable{T}"/>.</returns>
 		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
 		{
-			return Task.Run(() => QueryProvider.ExecuteAsyncEnumerable<T>(Expression, cancellationToken),
-				cancellationToken).Result.GetAsyncEnumerator(cancellationToken);
+			return QueryProvider.ExecuteAsyncEnumerable<T>(Expression, cancellationToken)
+				.Result.GetAsyncEnumerator(cancellationToken);
 		}
 
 		/// <summary>


### PR DESCRIPTION
In low thread condition offloading to Task.Run() results in deadlock since we block on Result. On the other side if thread is available old code also blocks on Result until QueryProvider returns. So call to Task.Run can be eliminated. 

Also note that ExpressionQuery<T>.ExecuteAsyncEnumerable() in linq2db is a sync call in scenarios that do not include "preambles" (so eg. typical read only queries). Thus by eliminating call to Task.Run in this scenario there never be a deadlock.