### PR TITLE
Fix #237 by using async IAsyncEnumerable<T>

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -158,8 +159,17 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 		/// <returns>Query result as <see cref="IAsyncEnumerable{T}"/>.</returns>
 		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
 		{
-			return Task.Run(() => QueryProvider.ExecuteAsyncEnumerable<T>(Expression, cancellationToken),
-				cancellationToken).Result.GetAsyncEnumerator(cancellationToken);
+			async IAsyncEnumerable<T> EnumerateAsyncEnumerable([EnumeratorCancellation] CancellationToken ct)
+			{
+				var asyncEnumerable = await QueryProvider.ExecuteAsyncEnumerable<T>(Expression, ct)
+					.ConfigureAwait(false);
+				await foreach (var item in asyncEnumerable.WithCancellation(ct))
+				{
+					yield return item;
+				}
+			}
+
+			return EnumerateAsyncEnumerable(cancellationToken).GetAsyncEnumerator(cancellationToken);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This likely means, that exceptions are thrown later (i.e. when starting to actually enumerate)