### PR TITLE
Added possibility to define default interceptors for Linq2Db.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ optionsBuilder.UseSqlite();
 optionsBuilder.UseLinqToDb(builder => 
 {
     builder.AddInterceptor(new MyCommandInterceptor());
-    builder.UseEfCoreRegisteredInterceptorsIfPossible();
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ optionsBuilder.UseSqlite();
 optionsBuilder.UseLinqToDb(builder => 
 {
     builder.AddInterceptor(new MyCommandInterceptor());
+    builder.TryToUseEfCoreRegisteredInterceptors();
 });
 ```
-As for the interceptors, if the interceptors added for EF Core do implement the `LinqToDB.Interceptors.IInterceptor` interface, they will be taken into consideration by LinqToDB automatically without any additional configuration.
 
 There are many extensions for CRUD Operations missing in vanilla EF ([watch our video](https://www.youtube.com/watch?v=m--oX73EGeQ)):
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ optionsBuilder.UseSqlite();
 optionsBuilder.UseLinqToDb(builder => 
 {
     builder.AddInterceptor(new MyCommandInterceptor());
-    builder.TryToUseEfCoreRegisteredInterceptors();
+    builder.UseEfCoreRegisteredInterceptorsIfPossible();
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,17 @@ LinqToDBForEFTools.Initialize();
 
 After that you can just call DbContext and IQueryable extension methods, provided by `LINQ To DB`.
 
-You can also optionally after invoking the above method define default interceptors to be used by LINQ To DB engine, here is an example:
+You can also register additional options (like interceptors) for LinqToDB during EF context registration, here is an example:
 
 ```cs
-var myInterceptor = new MyInterceptor(); //where MyInterceptor implements IInterceptor interface
-LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors.Add(myInterceptor);
+var optionsBuilder = new DbContextOptionsBuilder<MyDbContext>();
+optionsBuilder.UseSqlite();
+optionsBuilder.UseLinqToDb(builder => 
+{
+    builder.AddInterceptor(new MyCommandInterceptor());
+});
 ```
+As for the interceptors, if the interceptors added for EF Core do implement the `LinqToDB.Interceptors.IInterceptor` interface, they will be taken into consideration by LinqToDB automatically without any additional configuration.
 
 There are many extensions for CRUD Operations missing in vanilla EF ([watch our video](https://www.youtube.com/watch?v=m--oX73EGeQ)):
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ LinqToDBForEFTools.Initialize();
 
 After that you can just call DbContext and IQueryable extension methods, provided by `LINQ To DB`.
 
+You can also optionally after invoking the above method define default interceptors to be used by LINQ To DB engine, here is an example:
+
+```cs
+var myInterceptor = new MyInterceptor(); //where MyInterceptor implements IInterceptor interface
+LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors.Add(myInterceptor);
+```
+
 There are many extensions for CRUD Operations missing in vanilla EF ([watch our video](https://www.youtube.com/watch?v=m--oX73EGeQ)):
 
 ```cs

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;

--- a/Source/LinqToDB.EntityFrameworkCore/ILinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/ILinqToDBForEFTools.cs
@@ -14,6 +14,8 @@ namespace LinqToDB.EntityFrameworkCore
 	using Mapping;
 	using Metadata;
 	using Data;
+	using System.Collections.Generic;
+	using LinqToDB.Interceptors;
 
 	/// <summary>
 	/// Interface for EF Core - LINQ To DB integration bridge.
@@ -120,5 +122,9 @@ namespace LinqToDB.EntityFrameworkCore
 		/// </summary>
 		bool EnableChangeTracker { get; set; }
 		
+		/// <summary>
+		/// List of interceptors that should be added by default to data connections/contexts created from EF Core provider
+		/// </summary>
+		List<IInterceptor> DefaultLinq2DbInterceptors { get; set; }
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/ILinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/ILinqToDBForEFTools.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -15,7 +14,6 @@ namespace LinqToDB.EntityFrameworkCore
 	using Mapping;
 	using Metadata;
 	using Data;
-	using Interceptors;
 
 	/// <summary>
 	/// Interface for EF Core - LINQ To DB integration bridge.
@@ -121,10 +119,5 @@ namespace LinqToDB.EntityFrameworkCore
 		/// Entities will be attached only if AsNoTracking() is not used in query and DbContext is configured to track entities. 
 		/// </summary>
 		bool EnableChangeTracker { get; set; }
-		
-		/// <summary>
-		/// List of interceptors that should be added by default to data connections/contexts created from EF Core provider
-		/// </summary>
-		IList<IInterceptor> DefaultLinq2DbInterceptors { get; }
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/ILinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/ILinqToDBForEFTools.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -14,8 +15,7 @@ namespace LinqToDB.EntityFrameworkCore
 	using Mapping;
 	using Metadata;
 	using Data;
-	using System.Collections.Generic;
-	using LinqToDB.Interceptors;
+	using Interceptors;
 
 	/// <summary>
 	/// Interface for EF Core - LINQ To DB integration bridge.
@@ -125,6 +125,6 @@ namespace LinqToDB.EntityFrameworkCore
 		/// <summary>
 		/// List of interceptors that should be added by default to data connections/contexts created from EF Core provider
 		/// </summary>
-		List<IInterceptor> DefaultLinq2DbInterceptors { get; set; }
+		IList<IInterceptor> DefaultLinq2DbInterceptors { get; }
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LinqToDB.EntityFrameworkCore.Internal
+{
+	using Interceptors;
+
+	/// <summary>
+	/// Model containing LinqToDB related context options
+	/// </summary>
+	public class LinqToDBOptionsExtension : IDbContextOptionsExtension
+	{
+		private DbContextOptionsExtensionInfo? _info;
+		private IList<IInterceptor>? _interceptors;
+
+		/// <summary>
+		/// Context options extension info object
+		/// </summary>
+		public DbContextOptionsExtensionInfo Info 
+			=> _info ??= new LinqToDBExtensionInfo(this);
+
+		/// <summary>
+		/// List of registered LinqToDB interceptors
+		/// </summary>
+		public virtual IList<IInterceptor> Interceptors
+			=> _interceptors ??= new List<IInterceptor>();
+
+		/// <summary>
+		/// .ctor
+		/// </summary>
+		public LinqToDBOptionsExtension()
+		{
+		}
+
+		/// <summary>
+		/// .ctor
+		/// </summary>
+		/// <param name="copyFrom"></param>
+		protected LinqToDBOptionsExtension(LinqToDBOptionsExtension copyFrom)
+		{
+			_interceptors = copyFrom._interceptors;
+		}
+
+		/// Adds the services required to make the selected options work. This is used when
+		/// there is no external System.IServiceProvider and EF is maintaining its own service
+		/// provider internally. This allows database providers (and other extensions) to
+		/// register their required services when EF is creating an service provider.
+		/// <param name="services">The collection to add services to</param>
+		public void ApplyServices(IServiceCollection services)
+		{
+			;
+		}
+
+		/// <summary>
+		/// Gives the extension a chance to validate that all options in the extension are
+		/// valid. Most extensions do not have invalid combinations and so this will be a
+		/// no-op. If options are invalid, then an exception should be thrown.
+		/// </summary>
+		/// <param name="options"></param>
+		public void Validate(IDbContextOptions options)
+		{
+			;
+		}
+
+		private sealed class LinqToDBExtensionInfo : DbContextOptionsExtensionInfo
+		{
+			private string? _logFragment;
+
+			public LinqToDBExtensionInfo(IDbContextOptionsExtension extension)
+				: base(extension)
+			{
+			}
+
+			private new LinqToDBOptionsExtension Extension
+				=> (LinqToDBOptionsExtension)base.Extension;
+
+			public override bool IsDatabaseProvider
+				=> false;
+
+			public override string LogFragment
+			{
+				get
+				{
+					if (_logFragment == null)
+					{
+						var builder = new StringBuilder();
+
+						if (Extension.Interceptors.Any())
+						{
+							builder.Append($"Interceptors count: {Extension.Interceptors.Count}");
+						}
+
+						_logFragment = builder.ToString();
+					}
+
+					return _logFragment;
+				}
+			}
+
+			public override long GetServiceProviderHashCode()
+			{
+				return 0;
+			}
+
+			public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+				=> debugInfo["Linq2Db"] = "1";
+		}
+	}
+}

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -29,6 +29,12 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 			=> _interceptors ??= new List<IInterceptor>();
 
 		/// <summary>
+		/// If set to true the EF Core registered interceptors will be taken into consideration in Linq2Db logic
+		/// As long as they also implement Linq2Db interfaces
+		/// </summary>
+		public virtual bool TryToUseEfCoreInterceptors { get; internal set; }
+
+		/// <summary>
 		/// .ctor
 		/// </summary>
 		public LinqToDBOptionsExtension()

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -29,12 +29,6 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 			=> _interceptors ??= new List<IInterceptor>();
 
 		/// <summary>
-		/// If set to true the EF Core registered interceptors will be taken into consideration in Linq2Db logic
-		/// As long as they also implement Linq2Db interfaces
-		/// </summary>
-		public virtual bool TryToUseEfCoreInterceptors { get; internal set; }
-
-		/// <summary>
 		/// .ctor
 		/// </summary>
 		public LinqToDBOptionsExtension()

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -87,14 +87,14 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 				{
 					if (_logFragment == null)
 					{
-						var builder = new StringBuilder();
+						string logFragment = string.Empty;
 
 						if (Extension.Interceptors.Any())
 						{
-							builder.Append($"Interceptors count: {Extension.Interceptors.Count}");
+							logFragment += $"Interceptors count: {Extension.Interceptors.Count}";
 						}
 
-						_logFragment = builder.ToString();
+						_logFragment = logFragment;
 					}
 
 					return _logFragment;

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
@@ -31,5 +31,16 @@ namespace LinqToDB.EntityFrameworkCore
 			_extension.Interceptors.Add(interceptor);
 			return this;
 		}
+
+		/// <summary>
+		/// Make the Linq2Db try to use EF Core registered interceptors
+		/// As long as they also implement Linq2Db interfaces
+		/// </summary>
+		/// <returns></returns>
+		public LinqToDBContextOptionsBuilder TryToUseEfCoreRegisteredInterceptors(bool tryUseEfCoreInterceptors = true)
+		{
+			_extension.TryToUseEfCoreInterceptors = tryUseEfCoreInterceptors;
+			return this;
+		}
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace LinqToDB.EntityFrameworkCore
+{
+	using Internal;
+	using Interceptors;
+
+	/// <summary>
+	/// LinqToDB context options builder
+	/// </summary>
+	public class LinqToDBContextOptionsBuilder 
+	{
+		private readonly LinqToDBOptionsExtension _extension;
+
+		/// <summary>
+		/// .ctor
+		/// </summary>
+		/// <param name="optionsBuilder"></param>
+		public LinqToDBContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
+		{
+			_extension = optionsBuilder.Options.FindExtension<LinqToDBOptionsExtension>();
+		}
+
+		/// <summary>
+		/// Registers LinqToDb interceptor
+		/// </summary>
+		/// <param name="interceptor">The interceptor instance to register</param>
+		/// <returns></returns>
+		public LinqToDBContextOptionsBuilder AddInterceptor(IInterceptor interceptor)
+		{
+			_extension.Interceptors.Add(interceptor);
+			return this;
+		}
+	}
+}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
@@ -13,12 +13,18 @@ namespace LinqToDB.EntityFrameworkCore
 		private readonly LinqToDBOptionsExtension _extension;
 
 		/// <summary>
+		/// Db context options
+		/// </summary>
+		public DbContextOptions DbContextOptions { get; private set; }
+
+		/// <summary>
 		/// .ctor
 		/// </summary>
 		/// <param name="optionsBuilder"></param>
 		public LinqToDBContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
 		{
 			_extension = optionsBuilder.Options.FindExtension<LinqToDBOptionsExtension>();
+			DbContextOptions = optionsBuilder.Options;
 		}
 
 		/// <summary>
@@ -29,17 +35,6 @@ namespace LinqToDB.EntityFrameworkCore
 		public LinqToDBContextOptionsBuilder AddInterceptor(IInterceptor interceptor)
 		{
 			_extension.Interceptors.Add(interceptor);
-			return this;
-		}
-
-		/// <summary>
-		/// Make the Linq2Db use EF Core registered interceptors
-		/// as long as they also implement Linq2Db interfaces
-		/// </summary>
-		/// <returns></returns>
-		public LinqToDBContextOptionsBuilder UseEfCoreRegisteredInterceptorsIfPossible(bool useEfCoreInterceptors = true)
-		{
-			_extension.TryToUseEfCoreInterceptors = useEfCoreInterceptors;
 			return this;
 		}
 	}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBContextOptionsBuilder.cs
@@ -33,13 +33,13 @@ namespace LinqToDB.EntityFrameworkCore
 		}
 
 		/// <summary>
-		/// Make the Linq2Db try to use EF Core registered interceptors
-		/// As long as they also implement Linq2Db interfaces
+		/// Make the Linq2Db use EF Core registered interceptors
+		/// as long as they also implement Linq2Db interfaces
 		/// </summary>
 		/// <returns></returns>
-		public LinqToDBContextOptionsBuilder TryToUseEfCoreRegisteredInterceptors(bool tryUseEfCoreInterceptors = true)
+		public LinqToDBContextOptionsBuilder UseEfCoreRegisteredInterceptorsIfPossible(bool useEfCoreInterceptors = true)
 		{
-			_extension.TryToUseEfCoreInterceptors = tryUseEfCoreInterceptors;
+			_extension.TryToUseEfCoreInterceptors = useEfCoreInterceptors;
 			return this;
 		}
 	}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -298,7 +298,8 @@ namespace LinqToDB.EntityFrameworkCore
 			}
 
 			if (linq2DbExtension?.TryToUseEfCoreInterceptors == true
-				&& coreEfExtension?.Interceptors?.OfType<IInterceptor>().Any() == true)
+				&& coreEfExtension?.Interceptors != null)
+
 			{
 				interceptors.AddRange(coreEfExtension.Interceptors.OfType<IInterceptor>());
 			}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -278,7 +278,7 @@ namespace LinqToDB.EntityFrameworkCore
 			var contextOptions = ((IInfrastructure<IServiceProvider>)context.Database)?
 				.Instance?.GetService(typeof(IDbContextOptions)) as IDbContextOptions;
 
-			return contextOptions?.GetLinq2DbInterceptors() ?? new List<IInterceptor>();
+			return contextOptions?.GetLinq2DbInterceptors();
 		}
 
 		/// <summary>

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -269,7 +269,6 @@ namespace LinqToDB.EntityFrameworkCore
 		/// <summary>
 		/// Returns list of registered Linq2Db interceptors from EF Context
 		/// </summary>
-		/// <typeparam name="T">Mapping class type.</typeparam>
 		/// <returns>Db context object</returns>
 		public static IList<IInterceptor>? GetLinq2DbInterceptors(this DbContext context)
 
@@ -285,7 +284,6 @@ namespace LinqToDB.EntityFrameworkCore
 		/// <summary>
 		/// Returns list of registered Linq2Db interceptors from EF Context options
 		/// </summary>
-		/// <typeparam name="T">Mapping class type.</typeparam>
 		/// <returns>Db context options</returns>
 		public static IList<IInterceptor> GetLinq2DbInterceptors(this IDbContextOptions contextOptions)
 		{

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -271,7 +271,8 @@ namespace LinqToDB.EntityFrameworkCore
 		/// </summary>
 		/// <typeparam name="T">Mapping class type.</typeparam>
 		/// <returns>Db context object</returns>
-		public static IList<IInterceptor> GetLinq2DbInterceptors(this DbContext context)
+		public static IList<IInterceptor>? GetLinq2DbInterceptors(this DbContext context)
+
 		{
 			if (context == null) throw new ArgumentNullException(nameof(context));
 

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 using JetBrains.Annotations;
 
@@ -10,6 +11,9 @@ namespace LinqToDB.EntityFrameworkCore
 {
 	using Data;
 	using Linq;
+	using Internal;
+	using Interceptors;
+	using System.Linq;
 
 	public static partial class LinqToDBForEFTools
 	{
@@ -257,7 +261,51 @@ namespace LinqToDB.EntityFrameworkCore
 
 			return context.CreateLinqToDbContext().GetTable<T>();
 		}
-		
+
+		#endregion
+
+		#region Interceptors
+
+		/// <summary>
+		/// Returns list of registered Linq2Db interceptors from EF Context
+		/// </summary>
+		/// <typeparam name="T">Mapping class type.</typeparam>
+		/// <returns>Db context object</returns>
+		public static IList<IInterceptor> GetLinq2DbInterceptors(this DbContext context)
+		{
+			if (context == null) throw new ArgumentNullException(nameof(context));
+
+			var contextOptions = ((IInfrastructure<IServiceProvider>)context.Database)?
+				.Instance?.GetService(typeof(IDbContextOptions)) as IDbContextOptions;
+
+			return contextOptions?.GetLinq2DbInterceptors() ?? new List<IInterceptor>();
+		}
+
+		/// <summary>
+		/// Returns list of registered Linq2Db interceptors from EF Context options
+		/// </summary>
+		/// <typeparam name="T">Mapping class type.</typeparam>
+		/// <returns>Db context options</returns>
+		public static IList<IInterceptor> GetLinq2DbInterceptors(this IDbContextOptions contextOptions)
+		{
+			if (contextOptions == null) throw new ArgumentNullException(nameof(contextOptions));
+
+			var linq2DbExtension = contextOptions?.FindExtension<LinqToDBOptionsExtension>();
+			var coreEfExtension = contextOptions?.FindExtension<CoreOptionsExtension>();
+			List<IInterceptor> interceptors = new List<IInterceptor>();
+			if (coreEfExtension?.Interceptors?.OfType<IInterceptor>().Any() == true)
+			{
+				interceptors.AddRange(coreEfExtension.Interceptors.OfType<IInterceptor>());
+			}
+
+			if (linq2DbExtension?.Interceptors.Any() == true)
+			{
+				interceptors.AddRange(linq2DbExtension.Interceptors);
+			}
+
+			return interceptors;
+		}
+
 		#endregion
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -299,7 +299,8 @@ namespace LinqToDB.EntityFrameworkCore
 				interceptors.AddRange(coreEfExtension.Interceptors.OfType<IInterceptor>());
 			}
 
-			if (linq2DbExtension?.Interceptors.Any() == true)
+			if (linq2DbExtension?.Interceptors != null)
+
 			{
 				interceptors.AddRange(linq2DbExtension.Interceptors);
 			}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -292,15 +292,15 @@ namespace LinqToDB.EntityFrameworkCore
 			var linq2DbExtension = contextOptions?.FindExtension<LinqToDBOptionsExtension>();
 			var coreEfExtension = contextOptions?.FindExtension<CoreOptionsExtension>();
 			List<IInterceptor> interceptors = new List<IInterceptor>();
-			if (coreEfExtension?.Interceptors?.OfType<IInterceptor>().Any() == true)
-			{
-				interceptors.AddRange(coreEfExtension.Interceptors.OfType<IInterceptor>());
-			}
-
 			if (linq2DbExtension?.Interceptors != null)
-
 			{
 				interceptors.AddRange(linq2DbExtension.Interceptors);
+			}
+
+			if (linq2DbExtension?.TryToUseEfCoreInterceptors == true
+				&& coreEfExtension?.Interceptors?.OfType<IInterceptor>().Any() == true)
+			{
+				interceptors.AddRange(coreEfExtension.Interceptors.OfType<IInterceptor>());
 			}
 
 			return interceptors;

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextExtensions.cs
@@ -13,7 +13,6 @@ namespace LinqToDB.EntityFrameworkCore
 	using Linq;
 	using Internal;
 	using Interceptors;
-	using System.Linq;
 
 	public static partial class LinqToDBForEFTools
 	{
@@ -290,18 +289,10 @@ namespace LinqToDB.EntityFrameworkCore
 			if (contextOptions == null) throw new ArgumentNullException(nameof(contextOptions));
 
 			var linq2DbExtension = contextOptions?.FindExtension<LinqToDBOptionsExtension>();
-			var coreEfExtension = contextOptions?.FindExtension<CoreOptionsExtension>();
 			List<IInterceptor> interceptors = new List<IInterceptor>();
 			if (linq2DbExtension?.Interceptors != null)
 			{
 				interceptors.AddRange(linq2DbExtension.Interceptors);
-			}
-
-			if (linq2DbExtension?.TryToUseEfCoreInterceptors == true
-				&& coreEfExtension?.Interceptors != null)
-
-			{
-				interceptors.AddRange(coreEfExtension.Interceptors.OfType<IInterceptor>());
 			}
 
 			return interceptors;

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextOptionsBuilderExtensions.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.ContextOptionsBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace LinqToDB.EntityFrameworkCore
+{
+	using Internal;
+
+	public static partial class LinqToDBForEFTools
+	{
+		/// <summary>
+		/// Registers custom options related to LinqToDB provider
+		/// </summary>
+		/// <param name="optionsBuilder"></param>
+		/// <param name="linq2DbOptionsAction">Custom options action</param>
+		/// <returns></returns>
+		public static DbContextOptionsBuilder UseLinqToDb(
+			this DbContextOptionsBuilder optionsBuilder,
+			Action<LinqToDBContextOptionsBuilder>? linq2DbOptionsAction = null)
+		{
+			((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+				.AddOrUpdateExtension(GetOrCreateExtension(optionsBuilder));
+
+			linq2DbOptionsAction?.Invoke(new LinqToDBContextOptionsBuilder(optionsBuilder));
+
+			return optionsBuilder;
+		}
+
+		private static LinqToDBOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder options)
+			=> options.Options.FindExtension<LinqToDBOptionsExtension>()
+				?? new LinqToDBOptionsExtension();
+	}
+}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -25,7 +25,7 @@ namespace LinqToDB.EntityFrameworkCore
 	using Expressions;
 
 	using Internal;
-	using LinqToDB.Interceptors;
+	using Interceptors;
 
 	/// <summary>
 	/// EF Core <see cref="DbContext"/> extensions to call LINQ To DB functionality.
@@ -568,7 +568,7 @@ namespace LinqToDB.EntityFrameworkCore
 
 		private static void AddDefaultInterceptorsToDataContext(IDataContext dc)
 		{
-			if (dc != null && Implementation.DefaultLinq2DbInterceptors?.Any() == true)
+			if (dc != null && Implementation.DefaultLinq2DbInterceptors.Any())
 			{
 				foreach (var interceptor in Implementation.DefaultLinq2DbInterceptors)
 				{

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -578,7 +578,8 @@ namespace LinqToDB.EntityFrameworkCore
 		{
 			var registeredInterceptors = contextOptions?.GetLinq2DbInterceptors();
 
-			if (registeredInterceptors?.Any() == true
+			if (registeredInterceptors != null
+
 				&& dc != null )
 			{
 				foreach (var interceptor in registeredInterceptors)

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -38,7 +38,7 @@ namespace LinqToDB.EntityFrameworkCore
 	using DataProvider.SqlServer;
 	using DataProvider.SqlCe;
 	using System.Diagnostics.CodeAnalysis;
-	using LinqToDB.Interceptors;
+	using Interceptors;
 
 	// ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
 	/// <summary>
@@ -1160,6 +1160,6 @@ namespace LinqToDB.EntityFrameworkCore
 		/// <summary>
 		/// List of default interceptors that should be added to data connections created from EF Core provider
 		/// </summary>
-		public List<IInterceptor> DefaultLinq2DbInterceptors { get; set; } = new List<IInterceptor>();
+		public IList<IInterceptor> DefaultLinq2DbInterceptors { get; } = new List<IInterceptor>();
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -38,6 +38,7 @@ namespace LinqToDB.EntityFrameworkCore
 	using DataProvider.SqlServer;
 	using DataProvider.SqlCe;
 	using System.Diagnostics.CodeAnalysis;
+	using LinqToDB.Interceptors;
 
 	// ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
 	/// <summary>
@@ -1156,5 +1157,9 @@ namespace LinqToDB.EntityFrameworkCore
 		/// </summary>
 		public virtual bool EnableChangeTracker { get; set; } = true;
 
+		/// <summary>
+		/// List of default interceptors that should be added to data connections created from EF Core provider
+		/// </summary>
+		public List<IInterceptor> DefaultLinq2DbInterceptors { get; set; } = new List<IInterceptor>();
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -38,7 +38,6 @@ namespace LinqToDB.EntityFrameworkCore
 	using DataProvider.SqlServer;
 	using DataProvider.SqlCe;
 	using System.Diagnostics.CodeAnalysis;
-	using Interceptors;
 
 	// ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
 	/// <summary>
@@ -1156,10 +1155,5 @@ namespace LinqToDB.EntityFrameworkCore
 		/// Entities will be attached only if AsNoTracking() is not used in query and DbContext is configured to track entities. 
 		/// </summary>
 		public virtual bool EnableChangeTracker { get; set; } = true;
-
-		/// <summary>
-		/// List of default interceptors that should be added to data connections created from EF Core provider
-		/// </summary>
-		public IList<IInterceptor> DefaultLinq2DbInterceptors { get; } = new List<IInterceptor>();
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/Extensions/LinqToDBContextOptionsBuilderExtensions.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/Extensions/LinqToDBContextOptionsBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using LinqToDB.Interceptors;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors.Extensions
+{
+	public static class LinqToDBContextOptionsBuilderExtensions
+	{
+		public static void UseEfCoreRegisteredInterceptorsIfPossible(this LinqToDBContextOptionsBuilder builder)
+		{
+			var coreEfExtension = builder.DbContextOptions.FindExtension<CoreOptionsExtension>();
+			if (coreEfExtension?.Interceptors != null)
+			{
+				foreach (var comboInterceptor in coreEfExtension.Interceptors.OfType<IInterceptor>())
+				{
+					builder.AddInterceptor(comboInterceptor);
+				}
+			}
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestCommandInterceptor.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestCommandInterceptor.cs
@@ -1,0 +1,70 @@
+﻿using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqToDB.Common;
+using LinqToDB.Interceptors;
+
+namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors
+{
+	public class TestCommandInterceptor : TestInterceptor, ICommandInterceptor
+	{
+		public void AfterExecuteReader(CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, DbDataReader dataReader)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public void BeforeReaderDispose(CommandEventData eventData, DbCommand? command, DbDataReader dataReader)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task BeforeReaderDisposeAsync(CommandEventData eventData, DbCommand? command, DbDataReader dataReader)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+
+		public DbCommand CommandInitialized(CommandEventData eventData, DbCommand command)
+		{
+			HasInterceptorBeenInvoked = true;
+			return command;
+		}
+
+		public Option<int> ExecuteNonQuery(CommandEventData eventData, DbCommand command, Option<int> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public Task<Option<int>> ExecuteNonQueryAsync(CommandEventData eventData, DbCommand command, Option<int> result, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.FromResult(result);
+		}
+
+		public Option<DbDataReader> ExecuteReader(CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, Option<DbDataReader> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public Task<Option<DbDataReader>> ExecuteReaderAsync(CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, Option<DbDataReader> result, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.FromResult(result);
+		}
+
+		public Option<object?> ExecuteScalar(CommandEventData eventData, DbCommand command, Option<object?> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public Task<Option<object?>> ExecuteScalarAsync(CommandEventData eventData, DbCommand command, Option<object?> result, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.FromResult(result);
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestConnectionInterceptor.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestConnectionInterceptor.cs
@@ -1,0 +1,32 @@
+﻿using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqToDB.Interceptors;
+
+namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors
+{
+	public class TestConnectionInterceptor : TestInterceptor, IConnectionInterceptor
+	{
+		public void ConnectionOpened(ConnectionEventData eventData, DbConnection connection)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task ConnectionOpenedAsync(ConnectionEventData eventData, DbConnection connection, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+
+		public void ConnectionOpening(ConnectionEventData eventData, DbConnection connection)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task ConnectionOpeningAsync(ConnectionEventData eventData, DbConnection connection, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestDataContextInterceptor.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestDataContextInterceptor.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using LinqToDB.Interceptors;
+
+namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors
+{
+	public class TestDataContextInterceptor : TestInterceptor, IDataContextInterceptor
+	{
+		public void OnClosed(DataContextEventData eventData)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task OnClosedAsync(DataContextEventData eventData)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+
+		public void OnClosing(DataContextEventData eventData)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task OnClosingAsync(DataContextEventData eventData)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestEfCoreAndLinq2DbComboInterceptor.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestEfCoreAndLinq2DbComboInterceptor.cs
@@ -1,0 +1,176 @@
+﻿using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqToDB.Common;
+using LinqToDB.Interceptors;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors
+{
+	public class TestEfCoreAndLinq2DbComboInterceptor : TestInterceptor, ICommandInterceptor, IDbCommandInterceptor
+	{
+		#region LinqToDbInterceptor
+		public void AfterExecuteReader(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, DbDataReader dataReader)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public void BeforeReaderDispose(LinqToDB.Interceptors.CommandEventData eventData, DbCommand? command, DbDataReader dataReader)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task BeforeReaderDisposeAsync(LinqToDB.Interceptors.CommandEventData eventData, DbCommand? command, DbDataReader dataReader)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+
+		public DbCommand CommandInitialized(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command)
+		{
+			HasInterceptorBeenInvoked = true;
+			return command;
+		}
+
+		public Option<int> ExecuteNonQuery(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, Option<int> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public Task<Option<int>> ExecuteNonQueryAsync(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, Option<int> result, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.FromResult(result);
+		}
+
+		public Option<DbDataReader> ExecuteReader(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, Option<DbDataReader> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public Task<Option<DbDataReader>> ExecuteReaderAsync(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, Option<DbDataReader> result, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.FromResult(result);
+		}
+
+		public Option<object?> ExecuteScalar(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, Option<object?> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public Task<Option<object?>> ExecuteScalarAsync(LinqToDB.Interceptors.CommandEventData eventData, DbCommand command, Option<object?> result, CancellationToken cancellationToken)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.FromResult(result);
+		}
+		#endregion
+
+		#region EF core interceptor
+
+		public DbCommand CommandCreated(CommandEndEventData eventData, DbCommand result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public InterceptionResult<DbCommand> CommandCreating(CommandCorrelatedEventData eventData, InterceptionResult<DbCommand> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+		{
+			HasInterceptorBeenInvoked = true;
+		}
+
+		public Task CommandFailedAsync(DbCommand command, CommandErrorEventData eventData, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return Task.CompletedTask;
+		}
+		public InterceptionResult DataReaderDisposing(DbCommand command, DataReaderDisposingEventData eventData, InterceptionResult result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+		public int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public ValueTask<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return ValueTask.FromResult(result);
+		}
+
+		public InterceptionResult<int> NonQueryExecuting(DbCommand command, Microsoft.EntityFrameworkCore.Diagnostics.CommandEventData eventData, InterceptionResult<int> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, Microsoft.EntityFrameworkCore.Diagnostics.CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return ValueTask.FromResult(result);
+		}
+
+		public DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return ValueTask.FromResult(result);
+		}
+
+		public InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, Microsoft.EntityFrameworkCore.Diagnostics.CommandEventData eventData, InterceptionResult<DbDataReader> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, Microsoft.EntityFrameworkCore.Diagnostics.CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return ValueTask.FromResult(result);
+		}
+
+		public object ScalarExecuted(DbCommand command, CommandExecutedEventData eventData, object result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public ValueTask<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return ValueTask.FromResult(result);
+		}
+
+		public InterceptionResult<object> ScalarExecuting(DbCommand command, Microsoft.EntityFrameworkCore.Diagnostics.CommandEventData eventData, InterceptionResult<object> result)
+		{
+			HasInterceptorBeenInvoked = true;
+			return result;
+		}
+
+		public ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, Microsoft.EntityFrameworkCore.Diagnostics.CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+		{
+			HasInterceptorBeenInvoked = true;
+			return ValueTask.FromResult(result);
+		}
+
+		#endregion
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestEntityServiceInterceptor.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestEntityServiceInterceptor.cs
@@ -1,0 +1,16 @@
+﻿using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqToDB.Interceptors;
+
+namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors
+{
+	public class TestEntityServiceInterceptor : TestInterceptor, IEntityServiceInterceptor
+	{
+		public object EntityCreated(EntityCreatedEventData eventData, object entity)
+		{
+			HasInterceptorBeenInvoked = true;
+			return entity;
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestInterceptor.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Interceptors/TestInterceptor.cs
@@ -1,0 +1,12 @@
+﻿namespace LinqToDB.EntityFrameworkCore.BaseTests.Interceptors
+{
+	public abstract class TestInterceptor
+	{
+		public bool HasInterceptorBeenInvoked { get; protected set; }
+
+		public void ResetInvocations()
+		{
+			HasInterceptorBeenInvoked = false;
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -1,0 +1,121 @@
+﻿using System.Data.Common;
+using System.Linq;
+using LinqToDB.Data;
+using LinqToDB.EntityFrameworkCore.BaseTests;
+using LinqToDB.EntityFrameworkCore.BaseTests.Interceptors;
+using LinqToDB.EntityFrameworkCore.BaseTests.Models.Northwind;
+using LinqToDB.EntityFrameworkCore.SQLite.Tests.Models.Northwind;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
+{
+	[TestFixture]
+	public class InterceptorTests
+	{
+		private const string SQLITE_CONNECTION_STRING = "DataSource=NorthwindInMemory;Mode=Memory;Cache=Shared";
+		private readonly DbContextOptions _northwindOptions;
+		private DbConnection? _dbConnection;
+		static TestCommandInterceptor defaultCommandInterceptor;
+		static TestDataContextInterceptor defaultDataContextInterceptor;
+		static TestConnectionInterceptor defaultConnectionInterceptor;
+		static TestEntityServiceInterceptor defaultEntityServiceInterceptor;
+
+		static InterceptorTests()
+		{
+			defaultCommandInterceptor = new TestCommandInterceptor();
+			defaultDataContextInterceptor = new TestDataContextInterceptor();
+			defaultConnectionInterceptor = new TestConnectionInterceptor();
+			defaultEntityServiceInterceptor = new TestEntityServiceInterceptor();
+			LinqToDBForEFTools.Initialize();
+			LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors.Add(defaultCommandInterceptor);
+			LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors.Add(defaultDataContextInterceptor);
+			LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors.Add(defaultConnectionInterceptor);
+			LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors.Add(defaultEntityServiceInterceptor);
+			DataConnection.TurnTraceSwitchOn();
+		}
+
+		static DbContextOptions CreateNorthwindOptions()
+		{
+			var optionsBuilder = new DbContextOptionsBuilder<NorthwindContext>();
+			optionsBuilder.UseSqlite(SQLITE_CONNECTION_STRING);
+			optionsBuilder.UseLoggerFactory(TestUtils.LoggerFactory);
+
+			return optionsBuilder.Options;
+		}
+
+		public InterceptorTests()
+		{
+			_northwindOptions = CreateNorthwindOptions();
+		}
+
+		private NorthwindContext CreateContext()
+		{
+			var ctx = new NorthwindContext(_northwindOptions);
+			return ctx;
+		}
+
+		[SetUp]
+		public void Setup()
+		{
+			_dbConnection = new SqliteConnection(SQLITE_CONNECTION_STRING);
+			_dbConnection.Open();
+			using var ctx = new NorthwindContext(_northwindOptions);
+			ctx.Database.EnsureDeleted();
+			if (ctx.Database.EnsureCreated())
+			{
+				NorthwindData.Seed(ctx);
+			}
+			LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors
+				.ForEach(x => ((TestInterceptor)x).ResetInvocations());
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			_dbConnection?.Close();
+		}
+
+		[Test]
+		public void TestDefaultInterceptors()
+		{
+			using (var ctx = CreateContext())
+			{
+				var query =
+					from pd in ctx.Products
+					where pd.ProductId > 0
+					orderby pd.ProductId
+					select pd;
+				var items = query.Take(2).ToLinqToDB().ToArray();
+			}
+			Assert.IsTrue(defaultCommandInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(defaultConnectionInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(defaultEntityServiceInterceptor.HasInterceptorBeenInvoked);
+
+			//the following check is false because linq2db context is never closed together
+			//with the EF core context
+			Assert.IsFalse(defaultDataContextInterceptor.HasInterceptorBeenInvoked);
+		}
+
+		[Test]
+		public void TestExplicitDataContextDefaultInterceptors()
+		{
+			using (var ctx = CreateContext())
+			{
+				using var linq2DbContext = ctx.CreateLinqToDbContext();
+				var query =
+					from pd in ctx.Products
+					where pd.ProductId > 0
+					orderby pd.ProductId
+					select pd;
+				var items = query.Take(2).ToLinqToDB(linq2DbContext).ToArray();
+				var items2 = query.Take(2).ToLinqToDB(linq2DbContext).ToArray();
+			}
+			Assert.IsTrue(defaultCommandInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(defaultDataContextInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(defaultConnectionInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(defaultEntityServiceInterceptor.HasInterceptorBeenInvoked);
+		}
+	}
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -67,8 +67,11 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			{
 				NorthwindData.Seed(ctx);
 			}
-			LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors
-				.ForEach(x => ((TestInterceptor)x).ResetInvocations());
+
+			foreach (var interceptor in LinqToDBForEFTools.Implementation.DefaultLinq2DbInterceptors)
+			{
+				((TestInterceptor)interceptor).ResetInvocations();
+			}
 		}
 
 		[TearDown]

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using LinqToDB.Data;
 using LinqToDB.EntityFrameworkCore.BaseTests;
 using LinqToDB.EntityFrameworkCore.BaseTests.Interceptors;
+using LinqToDB.EntityFrameworkCore.BaseTests.Interceptors.Extensions;
 using LinqToDB.EntityFrameworkCore.BaseTests.Models.Northwind;
 using LinqToDB.EntityFrameworkCore.SQLite.Tests.Models.Northwind;
 using Microsoft.Data.Sqlite;

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -58,6 +58,10 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			var optionsBuilder = new DbContextOptionsBuilder<NorthwindContext>();
 			optionsBuilder.UseSqlite(SQLITE_CONNECTION_STRING);
 			optionsBuilder.AddInterceptors(testEfCoreAndLinq2DbInterceptor);
+			optionsBuilder.UseLinqToDb(builder =>
+			{
+				builder.TryToUseEfCoreRegisteredInterceptors();
+			});
 			optionsBuilder.UseLoggerFactory(TestUtils.LoggerFactory);
 
 			return optionsBuilder.Options;

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -92,16 +92,23 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			{
 				NorthwindData.Seed(ctx);
 			}
-
-			foreach (var interceptor in ctx.GetLinq2DbInterceptors())
+			var ctxInterceptors = ctx.GetLinq2DbInterceptors();
+			if (ctxInterceptors != null)
 			{
-				((TestInterceptor)interceptor).ResetInvocations();
+				foreach (var interceptor in ctxInterceptors)
+				{
+					((TestInterceptor)interceptor).ResetInvocations();
+				}
 			}
 
 			using var ctx2 = new NorthwindContext(_northwindOptionsWithoutLinq2DbExtensions);
-			foreach (var interceptor in ctx2.GetLinq2DbInterceptors())
+			var ctx2Interceptors = ctx2.GetLinq2DbInterceptors();
+			if (ctx2Interceptors != null)
 			{
-				((TestInterceptor)interceptor).ResetInvocations();
+				foreach (var interceptor in ctx2.GetLinq2DbInterceptors())
+				{
+					((TestInterceptor)interceptor).ResetInvocations();
+				}
 			}
 		}
 

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 	{
 		private const string SQLITE_CONNECTION_STRING = "DataSource=NorthwindInMemory;Mode=Memory;Cache=Shared";
 		private readonly DbContextOptions _northwindOptions;
-		private readonly DbContextOptions _northwindOptionsWithoutLinq2DbExtensions;
+		private readonly DbContextOptions _northwindOptionsWithEfCoreInterceptorsOnly;
 		private DbConnection? _dbConnection;
 		static TestCommandInterceptor testCommandInterceptor;
 		static TestDataContextInterceptor testDataContextInterceptor;
@@ -54,7 +54,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			return optionsBuilder.Options;
 		}
 
-		static DbContextOptions CreateNorthwindOptionsWithoutLinq2DbExtensions()
+		static DbContextOptions CreateNorthwindOptionsWithEfCoreInterceptorsOnly()
 		{
 			var optionsBuilder = new DbContextOptionsBuilder<NorthwindContext>();
 			optionsBuilder.UseSqlite(SQLITE_CONNECTION_STRING);
@@ -71,7 +71,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 		public InterceptorTests()
 		{
 			_northwindOptions = CreateNorthwindOptions();
-			_northwindOptionsWithoutLinq2DbExtensions = CreateNorthwindOptionsWithoutLinq2DbExtensions();
+			_northwindOptionsWithEfCoreInterceptorsOnly = CreateNorthwindOptionsWithEfCoreInterceptorsOnly();
 		}
 
 		private NorthwindContext CreateContext()
@@ -82,7 +82,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 
 		private NorthwindContext CreateContextWithountLinq2DbExtensions()
 		{
-			var ctx = new NorthwindContext(_northwindOptionsWithoutLinq2DbExtensions);
+			var ctx = new NorthwindContext(_northwindOptionsWithEfCoreInterceptorsOnly);
 			return ctx;
 		}
 
@@ -106,7 +106,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 				}
 			}
 
-			using var ctx2 = new NorthwindContext(_northwindOptionsWithoutLinq2DbExtensions);
+			using var ctx2 = new NorthwindContext(_northwindOptionsWithEfCoreInterceptorsOnly);
 			var ctx2Interceptors = ctx2.GetLinq2DbInterceptors();
 			if (ctx2Interceptors != null)
 			{

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -105,7 +105,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			var ctx2Interceptors = ctx2.GetLinq2DbInterceptors();
 			if (ctx2Interceptors != null)
 			{
-				foreach (var interceptor in ctx2.GetLinq2DbInterceptors())
+				foreach (var interceptor in ctx2Interceptors)
 				{
 					((TestInterceptor)interceptor).ResetInvocations();
 				}

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -18,19 +18,19 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 		private readonly DbContextOptions _northwindOptions;
 		private readonly DbContextOptions _northwindOptionsWithoutLinq2DbExtensions;
 		private DbConnection? _dbConnection;
-		static TestCommandInterceptor defaultCommandInterceptor;
-		static TestDataContextInterceptor defaultDataContextInterceptor;
-		static TestConnectionInterceptor defaultConnectionInterceptor;
-		static TestEntityServiceInterceptor defaultEntityServiceInterceptor;
-		static TestEfCoreAndLinq2DbComboInterceptor defaultTestEfCoreAndLinq2DbInterceptor;
+		static TestCommandInterceptor testCommandInterceptor;
+		static TestDataContextInterceptor testDataContextInterceptor;
+		static TestConnectionInterceptor testConnectionInterceptor;
+		static TestEntityServiceInterceptor testEntityServiceInterceptor;
+		static TestEfCoreAndLinq2DbComboInterceptor testEfCoreAndLinq2DbInterceptor;
 
 		static InterceptorTests()
 		{
-			defaultCommandInterceptor = new TestCommandInterceptor();
-			defaultDataContextInterceptor = new TestDataContextInterceptor();
-			defaultConnectionInterceptor = new TestConnectionInterceptor();
-			defaultEntityServiceInterceptor = new TestEntityServiceInterceptor();
-			defaultTestEfCoreAndLinq2DbInterceptor = new TestEfCoreAndLinq2DbComboInterceptor();
+			testCommandInterceptor = new TestCommandInterceptor();
+			testDataContextInterceptor = new TestDataContextInterceptor();
+			testConnectionInterceptor = new TestConnectionInterceptor();
+			testEntityServiceInterceptor = new TestEntityServiceInterceptor();
+			testEfCoreAndLinq2DbInterceptor = new TestEfCoreAndLinq2DbComboInterceptor();
 			LinqToDBForEFTools.Initialize();
 			DataConnection.TurnTraceSwitchOn();
 		}
@@ -41,10 +41,12 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			optionsBuilder.UseSqlite(SQLITE_CONNECTION_STRING);
 			optionsBuilder.UseLinqToDb(builder => 
 			{
-				builder.AddInterceptor(defaultCommandInterceptor);
-				builder.AddInterceptor(defaultDataContextInterceptor);
-				builder.AddInterceptor(defaultConnectionInterceptor);
-				builder.AddInterceptor(defaultEntityServiceInterceptor);
+				builder.AddInterceptor(testCommandInterceptor);
+				builder.AddInterceptor(testDataContextInterceptor);
+				builder.AddInterceptor(testConnectionInterceptor);
+				builder.AddInterceptor(testEntityServiceInterceptor);
+				builder.AddInterceptor(testEfCoreAndLinq2DbInterceptor);
+				builder.AddInterceptor(testCommandInterceptor);	//for checking the aggregated interceptors
 			});
 			optionsBuilder.UseLoggerFactory(TestUtils.LoggerFactory);
 
@@ -55,7 +57,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 		{
 			var optionsBuilder = new DbContextOptionsBuilder<NorthwindContext>();
 			optionsBuilder.UseSqlite(SQLITE_CONNECTION_STRING);
-			optionsBuilder.AddInterceptors(defaultTestEfCoreAndLinq2DbInterceptor);
+			optionsBuilder.AddInterceptors(testEfCoreAndLinq2DbInterceptor);
 			optionsBuilder.UseLoggerFactory(TestUtils.LoggerFactory);
 
 			return optionsBuilder.Options;
@@ -110,7 +112,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 		}
 
 		[Test]
-		public void TestDefaultInterceptors()
+		public void TestInterceptors()
 		{
 			using (var ctx = CreateContext())
 			{
@@ -121,17 +123,17 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 					select pd;
 				var items = query.Take(2).ToLinqToDB().ToArray();
 			}
-			Assert.IsTrue(defaultCommandInterceptor.HasInterceptorBeenInvoked);
-			Assert.IsTrue(defaultConnectionInterceptor.HasInterceptorBeenInvoked);
-			Assert.IsTrue(defaultEntityServiceInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testCommandInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testConnectionInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testEntityServiceInterceptor.HasInterceptorBeenInvoked);
 
 			//the following check is false because linq2db context is never closed together
 			//with the EF core context
-			Assert.IsFalse(defaultDataContextInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsFalse(testDataContextInterceptor.HasInterceptorBeenInvoked);
 		}
 
 		[Test]
-		public void TestExplicitDataContextDefaultInterceptors()
+		public void TestExplicitDataContextInterceptors()
 		{
 			using (var ctx = CreateContext())
 			{
@@ -144,10 +146,10 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 				var items = query.Take(2).ToLinqToDB(linq2DbContext).ToArray();
 				var items2 = query.Take(2).ToLinqToDB(linq2DbContext).ToArray();
 			}
-			Assert.IsTrue(defaultCommandInterceptor.HasInterceptorBeenInvoked);
-			Assert.IsTrue(defaultDataContextInterceptor.HasInterceptorBeenInvoked);
-			Assert.IsTrue(defaultConnectionInterceptor.HasInterceptorBeenInvoked);
-			Assert.IsTrue(defaultEntityServiceInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testCommandInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testDataContextInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testConnectionInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testEntityServiceInterceptor.HasInterceptorBeenInvoked);
 		}
 
 		[Test]
@@ -162,7 +164,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 					select pd;
 				var items = query.Take(2).ToArray();
 			}
-			Assert.IsTrue(defaultTestEfCoreAndLinq2DbInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testEfCoreAndLinq2DbInterceptor.HasInterceptorBeenInvoked);
 		}
 
 		[Test]
@@ -177,7 +179,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 					select pd;
 				var items = query.Take(2).ToLinqToDB().ToArray();
 			}
-			Assert.IsTrue(defaultTestEfCoreAndLinq2DbInterceptor.HasInterceptorBeenInvoked);
+			Assert.IsTrue(testEfCoreAndLinq2DbInterceptor.HasInterceptorBeenInvoked);
 		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/InterceptorTests.cs
@@ -60,7 +60,7 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests
 			optionsBuilder.AddInterceptors(testEfCoreAndLinq2DbInterceptor);
 			optionsBuilder.UseLinqToDb(builder =>
 			{
-				builder.TryToUseEfCoreRegisteredInterceptors();
+				builder.UseEfCoreRegisteredInterceptorsIfPossible();
 			});
 			optionsBuilder.UseLoggerFactory(TestUtils.LoggerFactory);
 


### PR DESCRIPTION
Ads possibility to define default interceptors for queries that uses Linq2Db engine (without the need of creating explicit DataContexts/DataConnections for them).

Related to feature request: https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/253
