### PR TITLE
Fixed SkipOnUpdate

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -262,15 +262,16 @@ namespace LinqToDB.EntityFrameworkCore
 							}
 						}
 
-						var behaviour = prop.GetBeforeSaveBehavior();
+						var beforeSaveBehaviour = prop.GetBeforeSaveBehavior();
 						var skipOnInsert = prop.ValueGenerated.HasFlag(ValueGenerated.OnAdd);
 
 						if (skipOnInsert)
 						{
-							skipOnInsert = isIdentity || behaviour != PropertySaveBehavior.Save;
+							skipOnInsert = isIdentity || beforeSaveBehaviour != PropertySaveBehavior.Save;
 						}
 
-						var skipOnUpdate = behaviour != PropertySaveBehavior.Save ||
+						var afterSaveBehaviour = prop.GetAfterSaveBehavior();
+						var skipOnUpdate = afterSaveBehaviour != PropertySaveBehavior.Save ||
 						                   prop.ValueGenerated.HasFlag(ValueGenerated.OnUpdate);
 
 						return new T[]


### PR DESCRIPTION
There may be properties which should be writeable only at insertion time (SkipOnInsert = false, SkipOnUpdate = true).
Atm, SkipOnUpdate is mapped from BeforeSaveBehavior, which is wrong, because it will skip value not only on update, but also on insert. SkipOnUpdate must be mapped from AfterSaveBehavior. Fixed.

