### PR TITLE
Add tests for DateTime to tstz mapping issue

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 		<PackageVersion Include="NUnit" Version="3.13.3" />
 		<PackageVersion Include="FluentAssertions" Version="6.10.0" />
 
-		<PackageVersion Include="linq2db" Version="5.1.0" />
-		<PackageVersion Include="linq2db.Tools" Version="5.1.0" />
+		<PackageVersion Include="linq2db" Version="5.2.0" />
+		<PackageVersion Include="linq2db.Tools" Version="5.2.0" />
 
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 
 		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="7.0.3" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.3" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
 

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.csproj
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.csproj
@@ -4,10 +4,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/NpgSqlEnititesContext.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/NpgSqlEnititesContext.cs
@@ -30,11 +30,19 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.Models.NpgSqlEntities
 				entity.Property<uint>(nameof(NpgSqlEntities.EntityWithXmin.xmin)).IsRowVersion();
 			});
 
+			modelBuilder.Entity<TimeStampEntity>(e =>
+			{
+				e.Property(e => e.Timestamp1).HasColumnType("timestamp");
+				e.Property(e => e.Timestamp2).HasColumnType("timestamp");
+				e.Property(e => e.TimestampTZ1).HasColumnType("timestamp with time zone");
+				e.Property(e => e.TimestampTZ2).HasColumnType("timestamp with time zone");
+				e.Property(e => e.TimestampTZ3).HasColumnType("timestamp with time zone");
+			});
 		}
 
 		public virtual DbSet<Event> Events { get; set; } = null!;
 		public virtual DbSet<EntityWithArrays> EntityWithArrays { get; set; } = null!;
 		public virtual DbSet<EntityWithXmin> EntityWithXmin { get; set; } = null!;
-
+		public virtual DbSet<TimeStampEntity> TimeStamps { get; set; } = null!;
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/TimeStampEntity.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/NpgSqlEntities/TimeStampEntity.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using NodaTime;
+
+namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.Models.NpgSqlEntities
+{
+	public class TimeStampEntity
+	{
+		public int            Id           { get; set; }
+		public DateTime       Timestamp1   { get; set; }
+		public LocalDateTime  Timestamp2   { get; set; }
+		public DateTime       TimestampTZ1 { get; set; }
+		public DateTimeOffset TimestampTZ2 { get; set; }
+		public Instant        TimestampTZ3 { get; set; }
+	}
+}


### PR DESCRIPTION
https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/213
https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/316
https://github.com/linq2db/linq2db/issues/3895
https://github.com/linq2db/linq2db/issues/3776

Fix will be added to linq2db as it is an issue in DateTime kind normalization where linq2db incorrectly identify column type as `timestamp without time zone` and remove kind from it