### PR TITLE
Fix sub-inheritance mapping attributes generation

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -144,19 +144,13 @@ namespace LinqToDB.EntityFrameworkCore
 
 			List<InheritanceMappingAttribute> ProcessEntityType(IEntityType et)
 			{
-				if (et.BaseType == null)
-				{
-					mappings.Add(new()
-					{
-						Type = et.ClrType, Code = entityType.GetDiscriminatorValue()
-					});
-					return mappings;
-				}
-
 				mappings.Add(new()
 				{
 					Type = et.ClrType, Code = entityType.GetDiscriminatorValue()
 				});
+				
+				if (et.BaseType == null)
+					return mappings;
 				return ProcessEntityType(et.BaseType);
 			}
 		}

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/ForMappingTestsBase.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/ForMappingTestsBase.cs
@@ -161,5 +161,22 @@ namespace LinqToDB.EntityFrameworkCore.BaseTests
 			pk.IsIdentity.Should().BeFalse();
 			Assert.AreEqual("Field", pk.ColumnName);
 		}
+
+		[Test]
+		public virtual async Task TestInheritance()
+		{
+			using var context = CreateContext();
+			using var connection = context.CreateLinqToDBConnection();
+			
+			context.WithInheritance.AddRange(new List<WithInheritanceA1>() { new() { }, new() { } });
+			context.WithInheritance.AddRange(new List<WithInheritanceA2>() { new() { }, new() { } });
+			await context.SaveChangesAsync();
+
+			var result = context.GetTable<WithInheritanceA>().ToList();
+			
+			result.OfType<WithInheritance>().Should().HaveCount(4);
+			result.OfType<WithInheritanceA1>().Should().HaveCount(2);
+			result.OfType<WithInheritanceA2>().Should().HaveCount(2);
+		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Models/ForMapping/ForMappingContextBase.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Models/ForMapping/ForMappingContextBase.cs
@@ -14,5 +14,10 @@ namespace LinqToDB.EntityFrameworkCore.BaseTests.Models.ForMapping
 		public DbSet<StringTypes> StringTypes { get; set; } = null!;
 
 		public DbSet<WithDuplicateProperties> WithDuplicateProperties { get; set; } = null!;
+		
+		public DbSet<WithInheritance> WithInheritance { get; set; } = null!;
+		public DbSet<WithInheritanceA> WithInheritanceA { get; set; } = null!;
+		public DbSet<WithInheritanceA1> WithInheritanceA1 { get; set; } = null!;
+		public DbSet<WithInheritanceA2> WithInheritanceA2 { get; set; } = null!;
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Models/ForMapping/WithInheritance.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Models/ForMapping/WithInheritance.cs
@@ -1,0 +1,22 @@
+﻿namespace LinqToDB.EntityFrameworkCore.BaseTests.Models.ForMapping;
+
+public class WithInheritance
+{
+	public int Id { get; set; }
+	public string Discriminator { get; set; } = null!;
+}
+
+public class WithInheritanceA : WithInheritance
+{
+	
+}
+
+public class WithInheritanceA1 : WithInheritanceA
+{
+	
+}
+
+public class WithInheritanceA2 : WithInheritanceA
+{
+	
+}

--- a/Tests/LinqToDB.EntityFrameworkCore.PomeloMySql.Tests/Models/ForMapping/ForMappingContext.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PomeloMySql.Tests/Models/ForMapping/ForMappingContext.cs
@@ -25,6 +25,11 @@ namespace LinqToDB.EntityFrameworkCore.PomeloMySql.Tests.Models.ForMapping
 			{
 				b.HasKey(e => e.Id);
 			});
+			
+			modelBuilder.Entity<WithInheritance>(b =>
+			{
+				b.HasDiscriminator(x => x.Discriminator);
+			});
 		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/ForMapping/ForMappingContext.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.PostgreSQL.Tests/Models/ForMapping/ForMappingContext.cs
@@ -23,6 +23,11 @@ namespace LinqToDB.EntityFrameworkCore.PostgreSQL.Tests.Models.ForMapping
 			{
 				b.HasKey(e => e.Id);
 			});
+			
+			modelBuilder.Entity<WithInheritance>(b =>
+			{
+				b.HasDiscriminator(x => x.Discriminator);
+			});
 		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/Models/ForMapping/ForMappingContext.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SQLite.Tests/Models/ForMapping/ForMappingContext.cs
@@ -20,6 +20,11 @@ namespace LinqToDB.EntityFrameworkCore.SQLite.Tests.Models.ForMapping
 			{
 				b.HasKey(e => e.Id);
 			});
+			
+			modelBuilder.Entity<WithInheritance>(b =>
+			{
+				b.HasDiscriminator(x => x.Discriminator);
+			});
 		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.SqlServer.Tests/Models/ForMapping/ForMappingContext.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SqlServer.Tests/Models/ForMapping/ForMappingContext.cs
@@ -30,6 +30,11 @@ namespace LinqToDB.EntityFrameworkCore.SqlServer.Tests.Models.ForMapping
 					b.Property(e => e.UnicodeString).HasMaxLength(50).IsUnicode();
 				}
 			);
+			
+			modelBuilder.Entity<WithInheritance>(b =>
+			{
+				b.HasDiscriminator(x => x.Discriminator);
+			});
 		}
 	}
 }


### PR DESCRIPTION
Hello.

This PR fixes generation of `InheritanceMappingAttribute` when you have stronger hierarchy than just one child.

### Example

Let's pretend we have such class hierarchy:
```C#
public class WithInheritance
{
  public int Id { get; set; }
  public string Discriminator { get; set; } = null!;
}

public class WithInheritanceA : WithInheritance { }

public class WithInheritanceA1 : WithInheritanceA { }

public class WithInheritanceA2 : WithInheritanceA { }
```

Then when you try to get all `WithInheritanceA` objects linq2db would create this query:
```sql
SELECT
  t1."Id",
  t1."Discriminator"
FROM
  "WithInheritance" t1
WHERE
  t1."Discriminator" = 'WithInheritanceA'
```

But that's wrong: inherited entities `WithInheritanceA1` and `WithInheritanceA2` also should be included in query. 
```sql
(t1."Discriminator" = 'WithInheritanceA'  OR
 t1."Discriminator" = 'WithInheritanceA1' OR 
 t1."Discriminator" = 'WithInheritanceA2')
```

<br/>
My PR fixes that problem by finding all relations between inherited types and then adding it to collection of mapping attributes.
Unit test also included, was tested on PgSql