### PR TITLE
Handle AsNoTrackingWithIdentityResolution

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -554,6 +554,7 @@ namespace LinqToDB.EntityFrameworkCore
 			MemberHelper.MethodOfGeneric<IIncludableQueryable<object, IEnumerable<object>>>(q => q.ThenInclude<object, object, object>(null!));
 
 		static readonly MethodInfo AsNoTrackingMethodInfo = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.AsNoTracking());
+		static readonly MethodInfo AsNoTrackingWithIdentityResolutionMethodInfo = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.AsNoTrackingWithIdentityResolution());
 
 		static readonly MethodInfo EFProperty = MemberHelper.MethodOfGeneric(() => EF.Property<object>(1, ""));
 
@@ -834,7 +835,8 @@ namespace LinqToDB.EntityFrameworkCore
 										methodCall.Arguments[0], Expression.NewArrayInit(typeof(Type)));
 									return new TransformInfo(newMethod, false, true);
 								}
-								else if (generic == AsNoTrackingMethodInfo)
+								else if (generic == AsNoTrackingMethodInfo
+									|| generic == AsNoTrackingWithIdentityResolutionMethodInfo)
 								{
 									isTunnel = true;
 									tracking = false;

--- a/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Models/ForMapping/WithInheritance.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.BaseTests/Models/ForMapping/WithInheritance.cs
@@ -1,22 +1,23 @@
-﻿namespace LinqToDB.EntityFrameworkCore.BaseTests.Models.ForMapping;
-
-public class WithInheritance
+﻿namespace LinqToDB.EntityFrameworkCore.BaseTests.Models.ForMapping
 {
-	public int Id { get; set; }
-	public string Discriminator { get; set; } = null!;
-}
+	public class WithInheritance
+	{
+		public int Id { get; set; }
+		public string Discriminator { get; set; } = null!;
+	}
 
-public class WithInheritanceA : WithInheritance
-{
-	
-}
+	public class WithInheritanceA : WithInheritance
+	{
 
-public class WithInheritanceA1 : WithInheritanceA
-{
-	
-}
+	}
 
-public class WithInheritanceA2 : WithInheritanceA
-{
-	
+	public class WithInheritanceA1 : WithInheritanceA
+	{
+
+	}
+
+	public class WithInheritanceA2 : WithInheritanceA
+	{
+
+	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.SqlServer.Tests/IssueTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SqlServer.Tests/IssueTests.cs
@@ -89,5 +89,13 @@ namespace LinqToDB.EntityFrameworkCore.SqlServer.Tests
 
 			var _ = ctx.Patents.AsSqlServer().ToLinqToDB().ToArray();
 		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/345")]
+		public void AsNoTrackingWithIdentityResolutionHandling()
+		{
+			using var ctx = CreateContext();
+
+			_ = ctx.Patents.AsNoTrackingWithIdentityResolution().ToLinqToDB().ToArray();
+		}
 	}
 }

--- a/Tests/LinqToDB.EntityFrameworkCore.SqlServer.Tests/ToolsTests.cs
+++ b/Tests/LinqToDB.EntityFrameworkCore.SqlServer.Tests/ToolsTests.cs
@@ -72,7 +72,7 @@ namespace LinqToDB.EntityFrameworkCore.SqlServer.Tests
 			if (ctx.Database.EnsureCreated())
 			{
 				NorthwindData.Seed(ctx);
-			}			
+			}
 			return ctx;
 		}
 


### PR DESCRIPTION
Fix #345

I wasn't able to reproduce exception too, so I've checked manually that we don't pass method to linq2db parser