### PR TITLE
Add EF 9.0.0-rc.2 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<Version>8.1.0</Version>
+		<Version>9.0.0</Version>
 
 		<Authors>Svyatoslav Danyliv, Igor Tkachev, Dmitry Lukashenko, Ilya Chudin</Authors>
 		<Product>Linq to DB</Product>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,27 +1,27 @@
 ﻿<Project>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageVersion Include="NUnit" Version="4.1.0" />
-		<PackageVersion Include="FluentAssertions" Version="6.12.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+		<PackageVersion Include="NUnit" Version="4.2.2" />
+		<PackageVersion Include="FluentAssertions" Version="6.12.1" />
 
-		<PackageVersion Include="linq2db" Version="5.4.0" />
-		<PackageVersion Include="linq2db.Tools" Version="5.4.0" />
+		<PackageVersion Include="linq2db" Version="5.4.1" />
+		<PackageVersion Include="linq2db.Tools" Version="5.4.1" />
 
-		<PackageVersion Include="NUnit.Analyzers" Version="4.0.1" />
-		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.145" />
+		<PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
+		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.173" />
 
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
 
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0-rc.2.24474.1" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-rc.2.24474.1" />
 
-		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0-rc.2.24473.5" />
 
-		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="8.0.2" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.1" />
+		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="9.0.0-rc.2" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-rc.2.24474.1" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-rc.2.24474.1" />
 
 		<PackageVersion Include="EntityFrameworkCore.FSharp" Version="6.0.7" />
 	</ItemGroup>

--- a/NuGet/linq2db.EntityFrameworkCore.nuspec
+++ b/NuGet/linq2db.EntityFrameworkCore.nuspec
@@ -15,8 +15,8 @@
 		<license type="file">MIT-LICENSE.txt</license>
 		<dependencies>
 			<group targetFramework="net8.0">
-				<dependency id="Microsoft.EntityFrameworkCore.Relational" version="8.0.0" />
-				<dependency id="linq2db" version="5.4.0" />
+				<dependency id="Microsoft.EntityFrameworkCore.Relational" version="9.0.0-rc.2.24474.1" />
+				<dependency id="linq2db" version="5.4.1" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -473,6 +473,9 @@ namespace LinqToDB.EntityFrameworkCore
 
 		sealed class SqlTransparentExpression : SqlExpression
 		{
+			//private static readonly ConstructorInfo _ctor = typeof(SqlTransparentExpression).GetConstructor([typeof(ExceptExpression), typeof(RelationalTypeMapping)])
+			//	?? throw new InvalidOperationException();
+
 			public Expression Expression { get; }
 
 			public SqlTransparentExpression(Expression expression, RelationalTypeMapping? typeMapping) : base(expression.Type, typeMapping)
@@ -483,6 +486,22 @@ namespace LinqToDB.EntityFrameworkCore
 			protected override void Print(ExpressionPrinter expressionPrinter)
 			{
 				expressionPrinter.PrintExpression(Expression);
+			}
+
+			public override Expression Quote()
+			{
+				// don't implement till first request or when we figure out how to quote Expression
+				throw new NotImplementedException("Quote is not implemented yet");
+
+//#pragma warning disable EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+//				return New(
+//					_ctor,
+//					// TODO: implement quoting
+//					// we pass only ConstantExpression here and
+//					// FromSqlExpression has example of ConstantExpression quotation
+//					Expression,
+//					RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
+//#pragma warning restore EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 			}
 
 			private bool Equals(SqlTransparentExpression other)

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsDataConnection.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsDataConnection.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace LinqToDB.EntityFrameworkCore
@@ -177,7 +176,7 @@ namespace LinqToDB.EntityFrameworkCore
 			if (!valid)
 				return entity;
 
-			entry = retrieved ?? _stateManager.StartTrackingFromQuery(_lastEntityType, entity, ValueBuffer.Empty);
+			entry = retrieved ?? _stateManager.StartTrackingFromQuery(_lastEntityType, entity, Snapshot.Empty);
 
 			return entry.Entity;
 		}

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -1,1 +1,2 @@
 [*.cs]
+dotnet_diagnostic.NUnit4001.severity = none

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,8 @@
 variables:
   solution: 'linq2db.EFCore.sln'
   build_configuration: 'Release'
-  assemblyVersion: 8.1.0
-  nugetVersion: 8.1.0
+  assemblyVersion: 9.0.0
+  nugetVersion: 9.0.0-rc.2
   artifact_nugets: 'nugets'
 
 # build on commits to important branches (master + release branches):
@@ -34,10 +34,10 @@ stages:
 
     
     - task: UseDotNet@2
-      displayName: 'Install .NET 8'
+      displayName: 'Install .NET 9'
       inputs:
         includePreviewVersions: true
-        version: 8.x
+        version: 9.x
 
     - task: PowerShell@2
       inputs:

--- a/linq2db.EFCore.sln
+++ b/linq2db.EFCore.sln
@@ -71,17 +71,13 @@ Global
 		{F65A1BBB-46F4-48A4-9778-1A5396A876AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F65A1BBB-46F4-48A4-9778-1A5396A876AE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0F013A9A-AC97-4A5E-A5D7-E1B64541CC46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F013A9A-AC97-4A5E-A5D7-E1B64541CC46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F013A9A-AC97-4A5E-A5D7-E1B64541CC46}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0F013A9A-AC97-4A5E-A5D7-E1B64541CC46}.Release|Any CPU.Build.0 = Release|Any CPU
 		{615C5697-5FA7-490C-8812-3D61994A8AC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{615C5697-5FA7-490C-8812-3D61994A8AC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{615C5697-5FA7-490C-8812-3D61994A8AC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{615C5697-5FA7-490C-8812-3D61994A8AC1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{ECF4637B-1C93-4D87-BDF2-E7F4DF7ED5C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ECF4637B-1C93-4D87-BDF2-E7F4DF7ED5C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ECF4637B-1C93-4D87-BDF2-E7F4DF7ED5C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ECF4637B-1C93-4D87-BDF2-E7F4DF7ED5C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Notes:
- Pomelo tests disabled as there is no provider available yet
- F# testing disabled as `EntityFrameworkCore.FSharp` is not compatible with EF 9 (and looking at https://github.com/efcore/EFCore.FSharp/issues/155 it looks like EF 9 will became EOL before compatible version released)
- new `SqlTransparentExpression.Quote` method is not implemented for now, awaiting for feedback